### PR TITLE
lock down jupyter-book version so it doesn't break CI

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -U jupyter-book sphinxcontrib.mermaid
+          pip install "jupyter-book<2" sphinxcontrib.mermaid
 
       - name: Build the book
         run: jupyter-book build ./docs --all


### PR DESCRIPTION
jupyter-book recently had a major v2.0 release which breaks CI, locking down version to keep using jupyter-book v1.0